### PR TITLE
option to cleanup and keep versions among promoted ones

### DIFF
--- a/clean_content_views.py
+++ b/clean_content_views.py
@@ -124,7 +124,7 @@ def cleanup(ver_list, ver_descr, dry_run, runuser, ver_keep, cleanall, ignorefir
 
         # Find version to delete (based on keep parameter) if --ignorefirstpromoted
         version_list_all.sort()
-        todelete = version_list_all[:(len(version_list_all) - ver_keep[cvid])]
+        todelete = version_list_all[:(len(version_list_all) - int(ver_keep[cvid]))]
         msg = "Versions to remove if --ignorefirstpromoted: " + str(todelete)
         helpers.log_msg(msg, 'DEBUG')
 


### PR DESCRIPTION
Hello,

I like the feature of "clean_content_views" to delete unused CVs keeping a specified number of backups.
By default this works for versions before the first one promoted (except if you use "--cleanall", that isn't what I need). 
Usually in our environment we need to delete versions among different promoted ones but keeping some of them:
```
v7.0 Library
v6.0 dev
v5.0  
v4.0 
v3.0 prod
v2.0
v1.0 goldenimg
```
To obtain it I added a new parameter "--ignorefirstpromoted" to start counting from the first version available rgardless the promoted one. For instance if I set "keep: 1" versions 2.0 and 4.0 will be deleted and 5.0 will my backup.